### PR TITLE
Windows対応: 静的解析モジュールの .bat/.cmd 実行・エンコーディング問題を修正

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -153,10 +153,25 @@ brew install pmd
 **Windows:**
 
 1. **Java**: [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) 等から Windows 用インストーラーをダウンロードして実行
-2. **Checkstyle**: [GitHub Releases](https://github.com/checkstyle/checkstyle/releases) から `checkstyle-X.X.X-all.jar` をダウンロードし、任意のフォルダに配置
-3. **PMD**: [公式サイト](https://pmd.github.io/) から ZIP ファイルをダウンロードし、任意のフォルダに解凍。環境変数 PATH に `bin` フォルダを追加
 
-配置や設定方法は各ツールの最新版のドキュメントを参照してください。
+2. **Checkstyle**: [GitHub Releases](https://github.com/checkstyle/checkstyle/releases) から `checkstyle-X.X.X-all.jar` をダウンロードし、任意のフォルダに配置。同じフォルダに以下の内容で `checkstyle.bat` を作成する（`checkstyle-X.X.X-all.jar` の部分はダウンロードしたファイル名に合わせること）：
+   ```bat
+   @echo off
+   java -jar "%~dp0checkstyle-X.X.X-all.jar" %*
+   ```
+
+3. **PMD**: [公式サイト](https://pmd.github.io/) から ZIP ファイルをダウンロードし、任意のフォルダに解凍。
+
+バックエンドを起動する PowerShell セッションで以下を実行し、PATH を設定してから `uv run uvicorn ...` を起動する（パスは実際の配置場所に合わせて変更）：
+
+```powershell
+$CHECKSTYLE_DIR = "C:\path\to\checkstyle"       # checkstyle.bat を置いたフォルダ
+$PMD_BIN        = "C:\path\to\pmd-bin-X.X.X\bin" # PMD の bin フォルダ
+
+$env:PATH = "$CHECKSTYLE_DIR;$PMD_BIN;" + $env:PATH
+```
+
+> **Note**: `where.exe checkstyle` および `where.exe pmd` で両コマンドが見つかることを確認してからバックエンドを起動してください。
 
 
 ### Python静的解析ツール

--- a/docs/samples/OrderService.java
+++ b/docs/samples/OrderService.java
@@ -1,0 +1,99 @@
+/**
+ * 注文管理サービスクラス
+ * 注文の登録・検索・キャンセルを提供する
+ */
+package com.example.order;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 注文サービス
+ */
+public class OrderService {
+
+    // --- static フィールド ---
+    private static final int MAX_ORDER_AMOUNT = 1000000;
+
+    // --- インスタンスフィールド ---
+    private List<Order> orderList;
+    private int sosakaisuu; // 規約違反(1): ローマ字変数名（操作回数）
+
+    // --- コンストラクタ ---
+    /**
+     * コンストラクタ
+     */
+    public OrderService() {
+        this.orderList = new ArrayList<>();
+        this.sosakaisuu = 0;
+    }
+
+    // --- メソッド ---
+
+    /**
+     * 注文を登録する
+     *
+     * @param customerId 顧客ID
+     * @param amount     注文金額
+     * @return 登録した注文
+     */
+    public Order registerOrder(String customerId, int amount) {
+        if (amount > MAX_ORDER_AMOUNT) {
+            throw new IllegalArgumentException("注文金額が上限を超えています");
+        }
+        Order order = new Order(customerId, amount, LocalDateTime.now());
+        orderList.add(order);
+        sosakaisuu++;
+        return order;
+    }
+
+    /**
+     * 顧客IDで注文を検索する
+     *
+     * @param customerId 顧客ID
+     * @return 該当する注文のリスト
+     */
+    public List<Order> findOrdersByCustomer(String customerId) {
+        List<Order> result = new ArrayList<>();
+        for (Order order : orderList) {
+            if (order.getCustomerId().equals(customerId)) {
+                result.add(order);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * 注文をキャンセルする
+     *
+     * @param orderId 注文ID
+     * @return キャンセル成功の場合 true
+     */
+    public boolean cancelOrder(String orderId) {
+        for (Order order : orderList) {
+            if (order.getOrderId().equals(orderId)) {
+                order.cancel();
+                sosakaisuu++;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // 規約違反(4)(5): メソッド名がローマ字かつ目的が不明瞭
+    public int getSosakaisuu() {
+        return sosakaisuu;
+    }
+
+    // 規約違反(10): Javadocなし
+    public boolean data(String customerId) {
+        return findOrdersByCustomer(customerId).isEmpty();
+    }
+
+    // 規約違反(8): 110文字を超える行
+    public String buildOrderSummary(String customerId) {
+        List<Order> orders = findOrdersByCustomer(customerId);
+        return "顧客ID: " + customerId + " の注文件数: " + orders.size() + " 件 / 操作回数: " + sosakaisuu + " 回 / 最大注文金額上限: " + MAX_ORDER_AMOUNT + " 円";
+    }
+}

--- a/docs/samples/OrderService_sjis.java
+++ b/docs/samples/OrderService_sjis.java
@@ -1,0 +1,99 @@
+/**
+ * 注文管理サービスクラス
+ * 注文の登録・検索・キャンセルを提供する
+ */
+package com.example.order;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 注文サービス
+ */
+public class OrderService {
+
+    // --- static フィールド ---
+    private static final int MAX_ORDER_AMOUNT = 1000000;
+
+    // --- インスタンスフィールド ---
+    private List<Order> orderList;
+    private int sosakaisuu; // 規約違反(1): ローマ字変数名（操作回数）
+
+    // --- コンストラクタ ---
+    /**
+     * コンストラクタ
+     */
+    public OrderService() {
+        this.orderList = new ArrayList<>();
+        this.sosakaisuu = 0;
+    }
+
+    // --- メソッド ---
+
+    /**
+     * 注文を登録する
+     *
+     * @param customerId 顧客ID
+     * @param amount     注文金額
+     * @return 登録した注文
+     */
+    public Order registerOrder(String customerId, int amount) {
+        if (amount > MAX_ORDER_AMOUNT) {
+            throw new IllegalArgumentException("注文金額が上限を超えています");
+        }
+        Order order = new Order(customerId, amount, LocalDateTime.now());
+        orderList.add(order);
+        sosakaisuu++;
+        return order;
+    }
+
+    /**
+     * 顧客IDで注文を検索する
+     *
+     * @param customerId 顧客ID
+     * @return 該当する注文のリスト
+     */
+    public List<Order> findOrdersByCustomer(String customerId) {
+        List<Order> result = new ArrayList<>();
+        for (Order order : orderList) {
+            if (order.getCustomerId().equals(customerId)) {
+                result.add(order);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * 注文をキャンセルする
+     *
+     * @param orderId 注文ID
+     * @return キャンセル成功の場合 true
+     */
+    public boolean cancelOrder(String orderId) {
+        for (Order order : orderList) {
+            if (order.getOrderId().equals(orderId)) {
+                order.cancel();
+                sosakaisuu++;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // 規約違反(4)(5): メソッド名がローマ字かつ目的が不明瞭
+    public int getSosakaisuu() {
+        return sosakaisuu;
+    }
+
+    // 規約違反(10): Javadocなし
+    public boolean data(String customerId) {
+        return findOrdersByCustomer(customerId).isEmpty();
+    }
+
+    // 規約違反(8): 110文字を超える行
+    public String buildOrderSummary(String customerId) {
+        List<Order> orders = findOrdersByCustomer(customerId);
+        return "顧客ID: " + customerId + " の注文件数: " + orders.size() + " 件 / 操作回数: " + sosakaisuu + " 回 / 最大注文金額上限: " + MAX_ORDER_AMOUNT + " 円";
+    }
+}

--- a/versions/v0.4/backend/app/services/static_analysis/base.py
+++ b/versions/v0.4/backend/app/services/static_analysis/base.py
@@ -1,5 +1,6 @@
 """ツール実行の基底クラスと共通ユーティリティ"""
 
+import shutil
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -51,7 +52,30 @@ class ToolRunner(ABC):
             relative_path = self._safe_relative_path(file_data)
             target_path = Path(tmpdir) / relative_path
             target_path.parent.mkdir(parents=True, exist_ok=True)
-            target_path.write_text(file_data.get("content", ""))
+
+            src_path = file_data.get("path")
+            if src_path:
+                # まずは非破壊でコピー（UTF-8ならこのままでOK）
+                shutil.copy2(src_path, target_path)
+                try:
+                    target_path.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    # CP932（Shift_JIS）の可能性が高いのでUTF-8に変換して書き戻す
+                    txt = target_path.read_text(encoding="cp932")
+                    target_path.write_text(txt, encoding="utf-8")
+                continue
+
+            if "content" in file_data:
+                data = file_data["content"]
+                if isinstance(data, (bytes, bytearray)):
+                    target_path.write_bytes(data)
+                elif isinstance(data, str):
+                    enc = file_data.get("encoding", "utf-8")
+                    target_path.write_text(data, encoding=enc, newline="\n")
+                else:
+                    raise TypeError("content must be bytes or str")
+            else:
+                raise ValueError("file spec must contain 'path' or 'content'")
 
     def _safe_relative_path(self, file_data: dict[str, str]) -> Path:
         """パストラバーサル攻撃を防止した相対パスを取得"""

--- a/versions/v0.4/backend/app/services/static_analysis/tool_checker.py
+++ b/versions/v0.4/backend/app/services/static_analysis/tool_checker.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from typing import Any
 
+from .utils.proc import run_capture
+
 logger = logging.getLogger(__name__)
 
 
@@ -58,15 +60,10 @@ class ToolChecker:
             return self._java_runtime_cache
 
         try:
-            result = subprocess.run(
-                ["java", "-version"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                # java -versionはstderrに出力される
-                output = (result.stderr or result.stdout or "").strip()
+            ret, out, err = run_capture(["java", "-version"], timeout=5)
+            if ret == 0 or out or err:
+                # java -version はstderrに出力される実装が多い
+                output = (err or out or "").strip()
                 java_version = self._extract_java_version(output)
                 self._java_runtime_cache = (True, None, java_version)
             else:
@@ -141,14 +138,9 @@ class ToolChecker:
 
         # ツール自体の確認
         try:
-            proc_result = subprocess.run(
-                tool_config["command"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if proc_result.returncode == 0:
-                output = (proc_result.stdout or proc_result.stderr or "").strip()
+            ret, out, err = run_capture(tool_config["command"], timeout=5)
+            if ret == 0 or out or err:
+                output = (out or err or "").strip()
                 version = self._extract_version(tool_name, output)
                 # Javaツールの場合、Javaバージョンを併記
                 if tool_config["language"] == "java" and java_version and version:

--- a/versions/v0.4/backend/app/services/static_analysis/tool_checker.py
+++ b/versions/v0.4/backend/app/services/static_analysis/tool_checker.py
@@ -167,11 +167,11 @@ class ToolChecker:
         return result
 
     def check_installed(self, tool_name: str) -> bool:
-        """指定ツールがインストールされているか確認（後方互換性用）"""
+        """指定ツールがインストールされているか確認"""
         return self.get_tool_availability(tool_name)["available"]
 
     def get_version(self, tool_name: str) -> str | None:
-        """ツールのバージョンを取得（後方互換性用）"""
+        """ツールのバージョンを取得"""
         return self.get_tool_availability(tool_name)["version"]
 
     def get_tools_availability(self) -> dict[str, Any]:

--- a/versions/v0.4/backend/app/services/static_analysis/tools/checkstyle.py
+++ b/versions/v0.4/backend/app/services/static_analysis/tools/checkstyle.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ..base import ToolRunner
+from ..utils.proc import run_capture
 
 logger = logging.getLogger(__name__)
 
@@ -43,33 +44,59 @@ class CheckstyleRunner(ToolRunner):
             else:
                 config_path = self._get_bundled_config()
 
+            if not Path(config_path).exists():
+                logger.error("Checkstyle config not found: %s", config_path)
+                return self._skipped("skipped_config_missing", str(config_path))
+
+            # tmpdir 配下の .java ファイルを列挙。0件なら早期リターン
+            java_files = [str(p) for p in Path(tmpdir).rglob("*.java")]
+            if not java_files:
+                return self._build_result(
+                    "executed",
+                    [],
+                    config_used=config_used,
+                    exit_code=0,
+                    duration_ms=None,
+                    version=self._get_version(),
+                )
+
             command = [
                 "checkstyle",
                 "-c",
                 str(config_path),
                 "-f",
                 "xml",
-                tmpdir,
+                *java_files,
             ]
 
             try:
                 with self._measure_time() as timer:
-                    result = subprocess.run(
-                        command,
-                        capture_output=True,
-                        text=True,
-                        timeout=self.timeout,
-                    )
+                    ret, out, err = run_capture(command, timeout=self.timeout)
 
-                violations = []
-                if result.returncode == 0 or result.stdout:
-                    violations = self._parse_xml(result.stdout)
+                # XML は通常 stdout。何もない場合は stderr も確認
+                raw_out = (out or "").strip()
+                raw_err = (err or "").strip()
+                xml_text = raw_out if raw_out.startswith("<") else (raw_err if raw_err.startswith("<") else "")
+                violations: list[dict[str, Any]] = []
+                if xml_text:
+                    violations = self._parse_xml(xml_text)
+                else:
+                    if ret == 0:
+                        logger.warning(
+                            "Checkstyle produced no XML output; treating as 0 violations. "
+                            "stdout=%r stderr=%r", raw_out[:200], raw_err[:200]
+                        )
+                    else:
+                        logger.error(
+                            "Checkstyle non-XML output (exit=%s). stdout=%r stderr=%r",
+                            ret, raw_out[:200], raw_err[:200]
+                        )
 
                 return self._build_result(
                     "executed",
                     violations,
                     config_used=config_used,
-                    exit_code=result.returncode,
+                    exit_code=ret,
                     duration_ms=timer.duration_ms,
                     version=self._get_version(),
                 )
@@ -96,13 +123,8 @@ class CheckstyleRunner(ToolRunner):
     def _get_version(self) -> str | None:
         """Checkstyleのバージョンを取得"""
         try:
-            result = subprocess.run(
-                ["checkstyle", "--version"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            output = (result.stdout or result.stderr or "").strip()
+            ret, out, err = run_capture(["checkstyle", "--version"], timeout=5)
+            output = (out or err or "").strip()
             return output.splitlines()[0] if output else None
         except Exception:
             return None

--- a/versions/v0.4/backend/app/services/static_analysis/tools/pmd.py
+++ b/versions/v0.4/backend/app/services/static_analysis/tools/pmd.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ..base import ToolRunner
+from ..utils.proc import run_capture
 
 logger = logging.getLogger(__name__)
 
@@ -64,14 +65,9 @@ class PMDRunner(ToolRunner):
 
             try:
                 with self._measure_time() as timer:
-                    result = subprocess.run(
-                        command,
-                        capture_output=True,
-                        text=True,
-                        timeout=self.timeout,
-                    )
+                    ret, out, err = run_capture(command, timeout=self.timeout)
 
-                violations = []
+                violations: list[dict[str, Any]] = []
                 # PMDは違反がある場合exit code 4を返す
                 if output_file.exists():
                     violations = self._parse_xml(output_file)
@@ -80,7 +76,7 @@ class PMDRunner(ToolRunner):
                     "executed",
                     violations,
                     config_used=config_used,
-                    exit_code=result.returncode,
+                    exit_code=ret,
                     duration_ms=timer.duration_ms,
                     version=self._get_version(),
                 )
@@ -107,13 +103,8 @@ class PMDRunner(ToolRunner):
         "PMD X.Y.Z" 形式の行を探して抽出する。
         """
         try:
-            result = subprocess.run(
-                ["pmd", "--version"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            output = (result.stdout or result.stderr or "").strip()
+            ret, out, err = run_capture(["pmd", "--version"], timeout=5)
+            output = (out or err or "").strip()
             if not output:
                 return None
 

--- a/versions/v0.4/backend/app/services/static_analysis/utils/proc.py
+++ b/versions/v0.4/backend/app/services/static_analysis/utils/proc.py
@@ -1,0 +1,56 @@
+"""コマンド実行共通ユーティリティ"""
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import Sequence, Tuple
+
+
+def resolve_cmd_on_windows(cmd: Sequence[str]) -> list[str]:
+    """
+    Windows でコマンド実体が .bat/.cmd の場合は ['cmd', '/c', 実体, ...] に変換。
+    shell=True を使わずにバッチを起動するための対策。
+    """
+    if not sys.platform.startswith("win"):
+        return list(cmd)
+    prog = cmd[0]
+    resolved = shutil.which(prog)  # PATH と PATHEXT を考慮
+    if resolved:
+        _, ext = os.path.splitext(resolved)
+        if ext.lower() in (".bat", ".cmd"):
+            return ["cmd", "/c", resolved, *cmd[1:]]
+    return list(cmd)
+
+
+def decode_with_fallback(data: bytes) -> str:
+    """
+    出力デコードを UTF-8 優先で行い、失敗時は cp932 → 既定エンコーディングへフォールバック。
+    最終手段のみ 'replace' を使用。
+    """
+    for enc in ("utf-8", "cp932", sys.getdefaultencoding()):
+        try:
+            return data.decode(enc)
+        except UnicodeDecodeError:
+            pass
+    return data.decode("utf-8", errors="replace")
+
+
+def run_capture(cmd: Sequence[str], timeout: float | None = None) -> Tuple[int, str, str]:
+    """
+    - Windows の .bat/.cmd を安全に起動（cmd /c ラップ）
+    - subprocess は常に text=False（バイナリ）で取得
+    - stdout/stderr はフォールバック・デコード
+    - shell=False 固定
+    """
+    cmd2 = resolve_cmd_on_windows(cmd)
+    proc = subprocess.run(
+        cmd2,
+        capture_output=True,
+        text=False,
+        timeout=timeout,
+        shell=False,
+    )
+    out = decode_with_fallback(proc.stdout or b"")
+    err = decode_with_fallback(proc.stderr or b"")
+    return proc.returncode, out, err

--- a/versions/v0.4/backend/tests/test_static_analysis.py
+++ b/versions/v0.4/backend/tests/test_static_analysis.py
@@ -274,6 +274,109 @@ class TestSeverityMapping:
         assert map_pylint_severity("unknown") == "warning"
 
 
+class TestProcUtils:
+    """utils/proc.py のテスト"""
+
+    def test_resolve_cmd_on_windows_wraps_bat(self):
+        """Windows 環境で .bat は cmd /c でラップされること"""
+        from unittest.mock import patch
+        from app.services.static_analysis.utils.proc import resolve_cmd_on_windows
+
+        with patch("app.services.static_analysis.utils.proc.sys") as mock_sys, \
+             patch("app.services.static_analysis.utils.proc.shutil.which",
+                   return_value=r"C:\tools\checkstyle.bat"):
+            mock_sys.platform = "win32"
+            result = resolve_cmd_on_windows(["checkstyle", "--version"])
+
+        assert result == ["cmd", "/c", r"C:\tools\checkstyle.bat", "--version"]
+
+    def test_resolve_cmd_on_non_windows_passthrough(self):
+        """Windows 以外ではコマンドがそのまま返ること"""
+        from app.services.static_analysis.utils.proc import resolve_cmd_on_windows
+
+        result = resolve_cmd_on_windows(["checkstyle", "--version"])
+        assert result == ["checkstyle", "--version"]
+
+    def test_decode_with_fallback_utf8(self):
+        """UTF-8 バイト列は正常にデコードできること"""
+        from app.services.static_analysis.utils.proc import decode_with_fallback
+
+        result = decode_with_fallback("hello".encode("utf-8"))
+        assert result == "hello"
+
+    def test_decode_with_fallback_cp932(self):
+        """CP932 バイト列が UTF-8 としてデコード失敗した後 CP932 で読めること"""
+        from app.services.static_analysis.utils.proc import decode_with_fallback
+
+        cp932_bytes = "日本語テスト".encode("cp932")
+        result = decode_with_fallback(cp932_bytes)
+        assert result == "日本語テスト"
+
+
+class TestCreateTempFiles:
+    """base.py _create_temp_files のテスト"""
+
+    def test_cp932_file_converted_to_utf8(self, tmp_path):
+        """path 指定の CP932 ファイルが UTF-8 に変換されて配置されること"""
+        from app.services.static_analysis.tools.checkstyle import CheckstyleRunner
+
+        # CP932 でエンコードされたファイルを用意
+        src = tmp_path / "source" / "Main.java"
+        src.parent.mkdir()
+        src.write_bytes("// 日本語コメント\nclass Main {}".encode("cp932"))
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        runner = CheckstyleRunner()
+        runner._create_temp_files(
+            [{"name": "Main.java", "path": str(src)}],
+            str(out_dir),
+        )
+
+        result = (out_dir / "Main.java").read_text(encoding="utf-8")
+        assert "日本語コメント" in result
+
+
+class TestCheckstyleRunner:
+    """CheckstyleRunnerのテスト"""
+
+    def test_run_no_java_files_returns_empty_violations(self):
+        """.javaファイルが0件の場合、空のviolationsで正常終了すること"""
+        from app.services.static_analysis.tools.checkstyle import CheckstyleRunner
+
+        runner = CheckstyleRunner()
+        # .javaファイルを含まないファイルリストを渡す
+        result = runner.run(
+            files=[{"name": "README.md", "content": "# test"}],
+            config_file=None,
+        )
+
+        assert result["status"] == "executed"
+        assert result["violations"] == []
+        assert result["exit_code"] == 0
+
+    def test_run_missing_config_returns_skipped(self):
+        """バンドルconfigが存在しない場合、skipped_config_missingが返ること"""
+        from pathlib import Path
+        from unittest.mock import patch
+        from app.services.static_analysis.tools.checkstyle import CheckstyleRunner
+
+        runner = CheckstyleRunner()
+        with patch.object(
+            runner,
+            "_get_bundled_config",
+            return_value=Path("/nonexistent/path/checkstyle.xml"),
+        ):
+            result = runner.run(
+                files=[{"name": "Main.java", "content": "class Main {}"}],
+                config_file=None,
+            )
+
+        assert result["status"] == "skipped_config_missing"
+        assert result["violations"] == []
+
+
 class TestTimeMeasure:
     """TimeMeasureのテスト"""
 


### PR DESCRIPTION
## Summary

- `utils/proc.py` を新規追加。Windows の `.bat/.cmd` を `shell=False` のまま安全に実行する `resolve_cmd_on_windows()` と、UTF-8/CP932 フォールバックデコードの `run_capture()` を実装
- `base._create_temp_files()` を拡張。`path` キーによる既存ファイルコピーと CP932→UTF-8 エンコーディング変換に対応
- `tool_checker` / `checkstyle` / `pmd` で `subprocess.run()` を `run_capture()` に統一
- `checkstyle`: config ファイル存在確認・`.java` ファイル列挙方式への変更・stdout/stderr 両対応の XML 取得ロジックを追加

Closes #13

## Test plan

- [x] macOS / Linux で既存の Checkstyle・PMD テストが通ること
- [x] Windows 環境（または `windows-latest` CI）で Checkstyle・PMD が `.bat/.cmd` 経由で正常に起動すること
- [x] CP932 エンコードされた日本語コメント入り Java ファイルを解析して `UnicodeDecodeError` が発生しないこと
- [x] `.java` ファイルが 0 件の場合に空の violations で正常終了すること
- [x] 存在しない config ファイルを指定した場合に `skipped_config_missing` が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)